### PR TITLE
video stream selection

### DIFF
--- a/include/ilp_gaffer_movie/av_reader.hpp
+++ b/include/ilp_gaffer_movie/av_reader.hpp
@@ -44,7 +44,7 @@ public:
   // Number of times the node has been refreshed.
   PLUG_MEMBER_DECL(refreshCountPlug, Gaffer::IntPlug);
 
-  PLUG_MEMBER_DECL(videoStreamIndexPlug, Gaffer::IntPlug);
+  PLUG_MEMBER_DECL(videoStreamPlug, Gaffer::StringPlug);
   PLUG_MEMBER_DECL(filterGraphPlug, Gaffer::StringPlug);
 
   PLUG_MEMBER_DECL(missingFrameModePlug, Gaffer::IntPlug);
@@ -119,6 +119,8 @@ protected:
     const GafferImage::ImagePlug *parent) const override;
 
 private:
+  std::optional<int> _videoStreamIndex(const Gaffer::Context *context) const;
+
   std::shared_ptr<void> _retrieveDecoder(const Gaffer::Context *context) const;
 
   std::shared_ptr<void> _retrieveFrame(

--- a/include/ilp_gaffer_movie/movie_reader.hpp
+++ b/include/ilp_gaffer_movie/movie_reader.hpp
@@ -67,7 +67,7 @@ public:
 
   PLUG_MEMBER_DECL(missingFrameModePlug, Gaffer::IntPlug);
 
-  PLUG_MEMBER_DECL(videoStreamIndexPlug, Gaffer::IntPlug);
+  PLUG_MEMBER_DECL(videoStreamPlug, Gaffer::StringPlug);
   PLUG_MEMBER_DECL(filterGraphPlug, Gaffer::StringPlug);
 
   PLUG_MEMBER_DECL(startModePlug, Gaffer::IntPlug);

--- a/include/ilp_movie/decoder.hpp
+++ b/include/ilp_movie/decoder.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>// std::size_t
 #include <cstdint>// int64_t, etc.
 #include <memory>// std::unique_ptr
+#include <optional>// std::optional
 #include <string>// std::string
 #include <vector>// std::vector
 
@@ -122,6 +123,10 @@ public:
   // Note that some properties, such as pixel format, may differ from the decoded frames,
   // since those are potentially pushed through a filter graph.
   [[nodiscard]] auto VideoStreamHeaders() const -> const std::vector<InputVideoStreamHeader> &;
+
+
+  [[nodiscard]] auto VideoStreamHeader(int stream_index) const
+    -> std::optional<InputVideoStreamHeader>;
 
   [[nodiscard]] auto
     DecodeVideoFrame(int stream_index, int frame_nb, DecodedVideoFrame &dvf) noexcept -> bool;

--- a/python/IlpGafferMovieUI/MovieReaderUI.py
+++ b/python/IlpGafferMovieUI/MovieReaderUI.py
@@ -177,18 +177,21 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The index of the video stream to be read. 
+			The video stream to be read. By default try to read the 'best' stream, as suggested 
+			by the decoder. To read a specific video stream provide a value on the form 'N',
+			where N is an integer corresponding to the stream index, e.g. '1'.
 			""",
 			#"presetNames", lambda plug : IECore.StringVectorData( [ str(x) for x in plug.node()["__avReader"]["availableStreamInfo"].getValue() ] ),
-			"presetNames", lambda plug : plug.node()["__avReader"]["availableVideoStreamInfo"].getValue(),
-			"presetValues", lambda plug : plug.node()["__avReader"]["availableVideoStreamIndices"].getValue(),
+			#"presetNames", lambda plug : plug.node()["__avReader"]["availableVideoStreamInfo"].getValue(),
+			#"presetValues", lambda plug : plug.node()["__avReader"]["availableVideoStreamIndices"].getValue(),
 
 			# "presetNames", IECore.StringVectorData( [ "best (stream #0)", "stream #0", "stream #1" ] ),
 			# "presetValues", IECore.IntVectorData( [ 0, 0, 1] ),
 
 			#"plugValueWidget:type", "IlpGafferMovieUI.MovieReaderUI._VideoStreamPlugValueWidget",
-			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			#"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
+			"label", "Video Stream",
 		],
 
 		"filterGraph" : [
@@ -237,9 +240,8 @@ Gaffer.Metadata.registerNode(
 		"fileValid" : [
 			"description",
 			"""
-			Whether or not the file exists and can be read into memory. Behaviour 
-			changes	if a frame mask of ClampToFrame or Black is selected, if outside
-			the frame mask fileValid will be set to True if the nearest frame is valid.
+			Whether or not the file exists and can be read into memory. Additionally, the 
+			file must contain at least one video stream.
 			""",
 
 			"layout:section", "Frames",
@@ -294,45 +296,45 @@ class _ColorSpacePlugValueWidget( GafferUI.PresetsPlugValueWidget ) :
 			return [ node["__intermediateColorSpace"] ]
 
 
-class _VideoStreamIndexPlugValueWidget( GafferUI.PresetsPlugValueWidget ) :
+# class _VideoStreamIndexPlugValueWidget( GafferUI.PresetsPlugValueWidget ) :
 
-	def __init__( self, plug, **kw ) :
+# 	def __init__( self, plug, **kw ) :
 
-		# self.__textWidget = GafferUI.TextWidget( editable = False )
-		GafferUI.PlugValueWidget.__init__( self, self.__textWidget, plug, **kw )
+# 		# self.__textWidget = GafferUI.TextWidget( editable = False )
+# 		GafferUI.PlugValueWidget.__init__( self, self.__textWidget, plug, **kw )
 
-	@staticmethod
-	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
+# 	@staticmethod
+# 	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
-		presets = GafferUI.PresetsPlugValueWidget._valuesForUpdate( plugs, [ [] for p in plugs ] )
+# 		presets = GafferUI.PresetsPlugValueWidget._valuesForUpdate( plugs, [ [] for p in plugs ] )
 
-		result = []
-		for preset, colorSpacePlugs in zip( presets, auxiliaryPlugs ) :
+# 		result = []
+# 		for preset, colorSpacePlugs in zip( presets, auxiliaryPlugs ) :
 
-			bestStream = ""
-			if len( colorSpacePlugs ) and preset == "Best" :
-				with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
-					automaticSpace = colorSpacePlugs[0].getValue() or "Working Space"
+# 			bestStream = ""
+# 			if len( colorSpacePlugs ) and preset == "Best" :
+# 				with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
+# 					automaticSpace = colorSpacePlugs[0].getValue() or "Working Space"
 
-			result.append( {
-				"preset" : preset,
-				"automaticSpace" : automaticSpace
-			} )
+# 			result.append( {
+# 				"preset" : preset,
+# 				"automaticSpace" : automaticSpace
+# 			} )
 
-		return result
+# 		return result
 
-	def _updateFromValues( self, values, exception ) :
+# 	def _updateFromValues( self, values, exception ) :
 
-		if not len( values ): 
-			self.__textWidget.setText( "---" )
+# 		if not len( values ): 
+# 			self.__textWidget.setText( "---" )
 
-		self.__textWidget.setErrored( exception is not None )
+# 		self.__textWidget.setErrored( exception is not None )
 
-	def _auxiliaryPlugs( self, plug ) :
+# 	def _auxiliaryPlugs( self, plug ) :
 
-		node = plug.node()
-		if isinstance( node, IlpGafferMovie.MovieReader ) :
-			return [ node["__avReader"] ]
+# 		node = plug.node()
+# 		if isinstance( node, IlpGafferMovie.MovieReader ) :
+# 			return [ node["__avReader"] ]
 
 
 class _AvailableFramesPlugValueWidget( GafferUI.PlugValueWidget ) :

--- a/src/ilp_gaffer_movie/internal/SharedFrames.cpp
+++ b/src/ilp_gaffer_movie/internal/SharedFrames.cpp
@@ -28,15 +28,6 @@ FrameLRUCache &cache()
       }
       assert(decoderEntry.decoder->IsOpen());// NOLINT
 
-      int video_stream_index = key.video_stream_index;
-      if (video_stream_index < 0) {
-        video_stream_index = decoderEntry.decoder->BestVideoStreamIndex();
-        if (video_stream_index < 0) { 
-          result.error = std::make_shared<std::string>("Bad video stream index");
-          return result; 
-        }
-      }
-
       try {
         auto dvf = std::make_unique<ilp_movie::DecodedVideoFrame>();
         if (!decoderEntry.decoder->DecodeVideoFrame(

--- a/src/ilp_gaffer_movie/movie_reader.cpp
+++ b/src/ilp_gaffer_movie/movie_reader.cpp
@@ -142,10 +142,10 @@ MovieReader::MovieReader(const std::string &name) : GafferImage::ImageNode(name)
     /*defaultValue=*/0));
   addChild(endPlug);// [4]
 
-  addChild(new IntPlug(// [5]
+  addChild(new StringPlug(// [5]
     /*name=*/"videoStreamIndex",
     /*direction=*/Plug::In,
-    /*defaultValue=*/-1));
+    /*defaultValue=*/"best"));
   addChild(new StringPlug(// [6]
     /*name=*/"filterGraph",
     /*direction=*/Plug::In,
@@ -194,7 +194,7 @@ MovieReader::MovieReader(const std::string &name) : GafferImage::ImageNode(name)
   avReader->fileNamePlug()->setInput(fileNamePlug());
   avReader->refreshCountPlug()->setInput(refreshCountPlug());
   avReader->missingFrameModePlug()->setInput(missingFrameModePlug());
-  avReader->videoStreamIndexPlug()->setInput(videoStreamIndexPlug());
+  avReader->videoStreamPlug()->setInput(videoStreamPlug());
   avReader->filterGraphPlug()->setInput(filterGraphPlug());
   _intermediateMetadataPlug()->setInput(avReader->outPlug()->metadataPlug());
   _intermediateFileValidPlug()->setInput(avReader->fileValidPlug());
@@ -243,7 +243,7 @@ PLUG_MEMBER_IMPL_SUB(startFramePlug, Gaffer::IntPlug, 3U, 1U);
 PLUG_MEMBER_IMPL_SUB(endModePlug, Gaffer::IntPlug, 4U, 0U);
 PLUG_MEMBER_IMPL_SUB(endFramePlug, Gaffer::IntPlug, 4U, 1U);
 
-PLUG_MEMBER_IMPL(videoStreamIndexPlug, Gaffer::IntPlug, 5U);
+PLUG_MEMBER_IMPL(videoStreamPlug, Gaffer::StringPlug, 5U);
 PLUG_MEMBER_IMPL(filterGraphPlug, Gaffer::StringPlug, 6U);
 
 PLUG_MEMBER_IMPL(colorSpacePlug, Gaffer::StringPlug, 7U);
@@ -333,7 +333,7 @@ void MovieReader::hash(const Gaffer::ValuePlug *output,
     _intermediateMetadataPlug()->hash(/*out*/ h);
     colorSpacePlug()->hash(/*out*/ h);
     fileNamePlug()->hash(/*out*/ h);
-    videoStreamIndexPlug()->hash(/*out*/ h);
+    videoStreamPlug()->hash(/*out*/ h);
     h.append(OCIOAlgo::currentConfigHash());
   } else if (output == fileValidPlug()) {
     TRACE("MovieReader", "hash - fileValid");


### PR DESCRIPTION
Adds a simple mechanism for video stream selection. Since it is hard to populate a combobox of choices (given that we never really know which decoder to use since the file name is context-dependent), we simply provide a string parameter. Users can input an integer index, e.g. '1', or give the special value 'best', that will use the video stream suggested by the decoder.